### PR TITLE
 - default `process.env.NODE_ENV` to `production`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
-## Upcoming
+# Changelog
 
-* Initial public release
+This project is following [Semantic Versioning](http://semver.org)
+
+## [Unreleased][]
+
+## [0.1.8][] - 2018-02-09
+
+ - default `process.env.NODE_ENV` to `production` when packaging the app for distribution with webpack  
+
+
+[Unreleased]: https://github.com/DeskproApps/github/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/DeskproApps/github/tree/v0.1.8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deskpro-app-github",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "This application adds support for viewing and creating GitHub issues.",
   "main": "lib/main/javascript/index.js",
   "scripts": {
@@ -8,7 +8,8 @@
     "lint": "eslint src/main/javascript/* --ext .js,.jsx --cache --cache-location=.cache/eslint",
     "lint:fix": "npm run lint -- --fix",
     "package": "dpat clean . && dpat compile . && dpat verify ./dist && dpat package .",
-    "test": "dpat test ."
+    "test": "dpat test .",
+    "version": "version-changelog CHANGELOG.md && changelog-verify CHANGELOG.md && git add CHANGELOG.md"
   },
   "repository": {
     "type": "git",
@@ -93,5 +94,9 @@
     "redux": "^3.7.2",
     "redux-form": "^7.1.2",
     "redux-thunk": "^2.2.0"
+  },
+  "optionalDependencies": {
+    "changelog-verify": "^1.1.0",
+    "version-changelog": "^2.1.0"
   }
 }

--- a/src/webpack/webpack.config-distribution.js
+++ b/src/webpack/webpack.config-distribution.js
@@ -5,6 +5,7 @@ module.exports = function (env) {
 
   const PROJECT_ROOT_PATH = env && env.DP_PROJECT_ROOT ? env.DP_PROJECT_ROOT : path.resolve(__dirname, '../../');
   const DEBUG = env && env.NODE_ENV === 'development';
+  const ENVIRONMENT =  env && env.NODE_ENV ? env.NODE_ENV : 'production';
 
   const buildManifest = new dpat.BuildManifest(
     PROJECT_ROOT_PATH,
@@ -67,7 +68,8 @@ module.exports = function (env) {
 
       new dpat.Webpack.DefinePlugin({
         DEBUG: DEBUG,
-        DPAPP_MANIFEST: JSON.stringify(buildManifest.getContent())
+        DPAPP_MANIFEST: JSON.stringify(buildManifest.getContent()),
+        'process.env.NODE_ENV': JSON.stringify(ENVIRONMENT)
       }),
 
       // for stable builds, in production we replace the default module index with the module's content hashe


### PR DESCRIPTION
 - default `process.env.NODE_ENV` to `production` when packaging the app for distribution with webpack