### PR TITLE
Fixed token for use only on the backend

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "title": "GitHub",
   "description": "View your GitHub issues from Deskpro and link them to tickets you are working on",
   "appStoreUrl": "https://www.deskpro.com/product-embed/apps/github",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "scope": "agent",
   "isSingleInstall": false,
   "hasDevMode": true,

--- a/src/pages/LogIn.tsx
+++ b/src/pages/LogIn.tsx
@@ -9,6 +9,7 @@ import {
 } from "@deskpro/app-sdk";
 import { useStore } from "../context/StoreProvider/hooks";
 import { getQueryParams } from "../utils";
+import { placeholders } from "../services/github/constants";
 import { AnchorButton } from "../components/common";
 import {
     getCurrentUserService,
@@ -87,7 +88,7 @@ const LogInPage: FC = () => {
                 return getAccessTokenService(client, clientId, token);
             })
             .then(({ access_token }) => {
-                return client?.setUserState("oauth2/token", access_token)
+                return client?.setUserState(placeholders.OAUTH_TOKEN_PATH, access_token, { backend: true })
             })
             .then((res) => {
                 return res?.isSuccess ? Promise.resolve() : Promise.reject()


### PR DESCRIPTION
Story https://app.shortcut.com/deskpro/story/96081/github-make-sure-the-token-is-stored-as-a-backend-only-value