### PR TITLE
If the text looks like a link in markdown, then we parse it as a link

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "title": "GitHub",
   "description": "View your GitHub issues from Deskpro and link them to tickets you are working on",
   "appStoreUrl": "https://www.deskpro.com/product-embed/apps/github",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "scope": "agent",
   "isSingleInstall": false,
   "hasDevMode": true,

--- a/src/utils/mdToHtml.ts
+++ b/src/utils/mdToHtml.ts
@@ -1,6 +1,11 @@
 import showdown from "showdown";
 
-const converter = new showdown.Converter();
+const converter = new showdown.Converter({
+    tables: true,
+    strikethrough: true,
+    simplifiedAutoLink: true,
+    openLinksInNewWindow: true,
+});
 
 const mdToHtml = (value: string): string => {
     return converter.makeHtml(value);


### PR DESCRIPTION
Story https://app.shortcut.com/deskpro/story/97087/github-links-aren-t-clickable